### PR TITLE
[WIP] Feat: add mediaType field for content of wysiwyg & markdown editors

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -7,7 +7,6 @@
 const present = require('present')
 const api = require('./helpers/api')
 const normalize = require('./helpers/normalize')
-const { downloadEntryImages } = require('./helpers/images')
 const { logInfo, logError } = require('./helpers/logger')
 
 /**
@@ -30,6 +29,16 @@ exports.sourceNodes = async (
     populate = true,
     firebaseConfig
   } = configOptions
+
+  const gatsbyHelpers = {
+    getNode,
+    touchNode,
+    createNode,
+    createNodeId,
+    store,
+    cache,
+    reporter
+  }
 
   try {
     logInfo('Starting with config:', JSON.stringify(configOptions))
@@ -96,26 +105,7 @@ exports.sourceNodes = async (
 
                 await Promise.all(
                   entries.map(async entry => {
-                    const data = await normalize.processContentEntry(
-                      schema.id,
-                      locale,
-                      entry,
-                      createNodeId
-                    )
-
-                    // download & inject local image
-                    await downloadEntryImages({
-                      entry: data,
-                      store,
-                      cache,
-                      createNode,
-                      createNodeId,
-                      reporter,
-                      getNode,
-                      touchNode
-                    })
-
-                    return createNode(data)
+                    return normalize.processContentEntry(schema.id, locale, entry, gatsbyHelpers)
                   })
                 )
               }


### PR DESCRIPTION
Hello!

I got some time to tackle one of the tasks mentioned in #7: support transforming images inside the content of wysiwyg editors, similar to what [gatsby-remark-images](https://www.gatsbyjs.org/packages/gatsby-remark-images/) does for markdown contents.

After studying the [contentful source plugin](https://www.gatsbyjs.org/packages/gatsby-source-contentful/), I realize that flamelink's markdown fields can be transformed by `gatsby-transformer-remark`, as long as we create separate markdown content nodes that contain a `mediaType: text/markdown` field. This means that flamelink's markdown users can fully take advantage of gatsby's remark ecosystem.

To do this, we need to create a new intermediate node type, say `FlamelinkMarkdownContent` that contains a `mediaType` field, then link it to the original entry node:

```
# schema
Blog
  |-- title: text
  |-- description: textarea
  `-- content: markdown-editor

# current
blogEntry: FlamelinkBlogContent
  |-- title: string
  |-- description: string
  `-- content: string

# proposal
blogEntry: FlamelinkBlogContent
  |-- title: string
  |-- description: string
  `-- content: FlamelinkMarkdownContent
          |-- content: string
          `-- childMarkdownRemark: MarkdownRemark
                   `-- html: string
```

Currently, `processContentEntry` is in charge of turning each entry into a node. However, for this proposal to work, it also needs to create children nodes like markdown nodes. I think it'd be a little cleaner to pass `createNode` into `processContentEntry`, where an entry & its children nodes can be created.
```js
// current
entries.map(async entry => {
  const data = normalize.processContentEntry(schema.id, locale, entry, createNodeId)
  // handle image fields
  return createNode(data)
})

// proposal
entries.map(async entry => {
  // image fields can now be handled inside `processContentEntry`
  return normalize.processContentEntry(schema.id, locale, entry, createNodeId, createNode)
})
```

Then, inside `processContentEntry`, we can map through `fieldTypes` to find content nodes, create those nodes, then link them back to the main entry node:
```js
// (pseudo code)
// entry: { title: 'Hello', description: 'test', content: '#Title \n - bullet point' }
// fieldTypes: { title: 'text', description: 'text-area', content: 'markdown-editor' }

const contentNodes = Object.keys(fieldTypes).map(key => {
  if (fieldTypes[key] === 'markdown-editor') {
    const contentNode = createContentNode(entry, key)

    // link content node to its original field & remove the original field
    entry[`${key}___NODE`] = contentNode.id
    delete entry[key]
  } 
}

contentNodes.forEach(node => createNode(node))
createNode(entry)
```

Then in user land, if they have `gatsby-transformer-remark` installed, they can query the html:
```
query AllBlog {
  posts: allFlamelinkBlogContent {
    nodes {
      title
      description
      content_markdown {
        content                      --> '#Title \n - bullet point'
        childMarkdownRemark {
          html                       --> '<h1>Title</h1><ul><li>bullet point</li></ul>'
        }
      }
    }
  }
}
```

### Notes
- Beside `text/markdown`, I also add `mediaType: text/html` for `wysiwyg` & `wysiwyg-cke` so other gatsby plugins can transform these html nodes. If Flamelink has more editor types i.e rich text or csv, those types can be added as well.

- If this current code gets merged, it'll be a breaking change; the original content field is being replaced with an object. We can make it non-breaking by pushing the content node into a different field (maybe the same field name with suffix `transformed` or `processed`?), though I feel like replacing the same field & bumping up the semver is better

- I have a test Flamelink project where I try out different schemas but it only has 1 seat, it'd be nice if we can set up a Flamelink project that's accessible to contributors so everyone sees the same thing

### todos
Some to-dos if we move forward with this:
- [ ] The logic of `processContentEntry` is getting a bit hard to follow, so it's probably a good idea to break it into smaller functions
- [ ] Add some tests for the filtering logic

Please let me know what you think. I try to follow the existing code style & convention as much as I can, if you spot something weird please don't hesitate to mark it down!