### PR TITLE
Bugfix/gh 27 fl meta date fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ yarn add gatsby-source-flamelink
 
 ## How to use
 
-// In your gatsby-config.js
+In order to use the plugin you need to configure it to point to the Firebase instance that is using Flamelink.
+To do this you will need to create a service account (if you haven't already) and download the JSON file for
+the service account. You will also need your Firebase configuration details. Once you have these details
+add the following to your config file:
+
 
 ```javascript
+// In your gatsby-config.js
 plugins: [
   {
     resolve: 'gatsby-source-flamelink',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "debug": "4.1.1",
     "firebase-admin": "8.9.0",
     "flamelink": "1.0.0-alpha.28",
+    "flat": "^5.0.0",
     "lodash": "4.17.15",
     "pascalcase": "1.0.0",
     "present": "1.0.0"

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -23,7 +23,7 @@ exports.parseFirebaseTimestamps = entry => {
    * it on to be parsed into a UTC string.
    */
   Object.keys(flattenedEntry)
-    .filter(key => key.includes('_seconds'))
+    .filter(key => key.endsWith('._seconds'))
     .forEach(flattenedKey => {
       const key = flattenedKey.split('._seconds')[0]
       set(entry, key, parseFirebaseDate(get(entry, key)))

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -14,7 +14,7 @@ const parseFirebaseDate = timestampObject => {
 /**
  * Iterate over an object and parse all Firebase Timestamp objects to UTC strings
  */
-exports.parseMetaTimestamps = entry => {
+exports.parseFirebaseTimestamps = entry => {
   const flattenedEntry = flatten(entry)
   /**
    * After flattening the entry a Firebase timestamp can be found by looking for keys that

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1,0 +1,32 @@
+const flatten = require('flat')
+const { set, get } = require('lodash')
+
+/**
+ * Parse a Firebase Timestamp object to a UTC string
+ */
+const parseFirebaseDate = timestampObject => {
+  if (timestampObject && timestampObject.toDate && typeof timestampObject.toDate === 'function') {
+    return timestampObject.toDate()
+  }
+  return timestampObject
+}
+
+/**
+ * Iterate over an object and parse all Firebase Timestamp objects to UTC strings
+ */
+exports.parseMetaTimestamps = entry => {
+  const flattenedEntry = flatten(entry)
+  /**
+   * After flattening the entry a Firebase timestamp can be found by looking for keys that
+   * contains either a `_seconds` or a `_nanoseconds` property. We'll look for the `_seconds`
+   * key. Once found we know that the related entry is a Firebase timestamp and we pass
+   * it on to be parsed into a UTC string.
+   */
+  Object.keys(flattenedEntry)
+    .filter(key => key.includes('_seconds'))
+    .forEach(flattenedKey => {
+      const key = flattenedKey.split('._seconds')[0]
+      set(entry, key, parseFirebaseDate(get(entry, key)))
+    })
+  return entry
+}

--- a/src/helpers/normalize.js
+++ b/src/helpers/normalize.js
@@ -2,7 +2,7 @@ const compose = require('compose-then')
 const { result, isPlainObject, curry, get, keys } = require('lodash')
 const pascalCase = require('pascalcase')
 const { downloadEntryImages } = require('./images')
-const { parseMetaTimestamps } = require('./helpers')
+const { parseFirebaseTimestamps } = require('./helpers')
 
 // RESERVED_FIELDS from here https://www.gatsbyjs.org/docs/node-interface/
 const RESERVED_FIELDS = ['id', 'children', 'parent', 'fields', 'internal', '__meta__']
@@ -54,7 +54,7 @@ const prepareKeys = entry => {
   })
 
   // Find and convert Firebase Timestamp objects to UTC strings
-  newEntry = parseMetaTimestamps(newEntry)
+  newEntry = parseFirebaseTimestamps(newEntry)
 
   return newEntry
 }

--- a/src/helpers/normalize.js
+++ b/src/helpers/normalize.js
@@ -2,6 +2,7 @@ const compose = require('compose-then')
 const { result, isPlainObject, curry, get, keys } = require('lodash')
 const pascalCase = require('pascalcase')
 const { downloadEntryImages } = require('./images')
+const { parseMetaTimestamps } = require('./helpers')
 
 // RESERVED_FIELDS from here https://www.gatsbyjs.org/docs/node-interface/
 const RESERVED_FIELDS = ['id', 'children', 'parent', 'fields', 'internal', '__meta__']
@@ -38,7 +39,7 @@ const prepareKeys = entry => {
     return entry
   }
 
-  const newEntry = { ...entry }
+  let newEntry = { ...entry }
   keys(newEntry).forEach(key => {
     const newKey = getValidKey(key)
     newEntry[newKey] = newEntry[key]
@@ -51,6 +52,9 @@ const prepareKeys = entry => {
       newEntry[newKey] = newEntry[newKey].map(prepareKeys)
     }
   })
+
+  // Find and convert Firebase Timestamp objects to UTC strings
+  newEntry = parseMetaTimestamps(newEntry)
 
   return newEntry
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,6 +3180,13 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
+flat@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.0.tgz#dab7d71d60413becb0ac2de9bf4304495e3af6af"
+  integrity sha512-6KSMM+cHHzXC/hpldXApL2S8Uz+QZv+tq5o/L0KQYleoG+GcwrnIJhTWC7tCOiKQp8D/fIvryINU1OZCCwevjA==
+  dependencies:
+    is-buffer "~2.0.4"
+
 flatted@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
@@ -3820,6 +3827,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Issue:**
Certain meta date fields are not showing up in GraphQL. The issue is that we use  `JSON.stringify()` on entries and that will not convert Firebase Timestamp objects or rather it will convert them to `undefined` (similar to how a function would become undefined when trying to JSON.stringify it). As a result the undefined keys get stripped and don't appear in GraphQL.

**Solution:**
Parse all Firebase Timestamp objects in a given nested entry to UTC date strings so that when the entry gets picked up by `JSON.stringify()` the date fields don't get stripped.

