### PR TITLE
fix: Ensure globals default to empty object when not defined

### DIFF
--- a/src/helpers/normalize.js
+++ b/src/helpers/normalize.js
@@ -455,7 +455,7 @@ const processNavigation = async ({ locale, nav, gatsbyHelpers }) => {
 
 exports.processNavigation = processNavigation
 
-const processGlobals = ({ globalsData, gatsbyHelpers }) => {
+const processGlobals = ({ globalsData = {}, gatsbyHelpers }) => {
   const preppedGlobals = prepareKeys(globalsData)
   const nodeId = gatsbyHelpers.createNodeId(`flamelink-globals`)
 

--- a/src/helpers/normalize.js
+++ b/src/helpers/normalize.js
@@ -455,8 +455,8 @@ const processNavigation = async ({ locale, nav, gatsbyHelpers }) => {
 
 exports.processNavigation = processNavigation
 
-const processGlobals = ({ globalsData = {}, gatsbyHelpers }) => {
-  const preppedGlobals = prepareKeys(globalsData)
+const processGlobals = ({ globalsData, gatsbyHelpers }) => {
+  const preppedGlobals = prepareKeys(globalsData || {})
   const nodeId = gatsbyHelpers.createNodeId(`flamelink-globals`)
 
   return {


### PR DESCRIPTION
**Issue:**
When creating a new Flamelink project the `globals` object won't exist in the Firebase DB under the `fl_settings` collection and this will cause the gatsby source plugin to throw on the `normalize.processGlobals()` method.

**Solution:**
Default `globals` parameter on the `normalize.processGlobals()` method to an empty object.